### PR TITLE
feat: adding physics_update method to State interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/source/State.gd
+++ b/source/State.gd
@@ -21,17 +21,21 @@ func load_context(saved_context):
     context = saved_context
     
 # called from the StateMachine _process method
-func update(_delta, _owner_obj):
+func update(_delta, _owner):
+    pass
+
+# called from StateMachine._physics_process 
+func physics_update(_delta, _owner):
     pass
 
 # called from _input
-func handle_input(_event, _owner_obj):
+func handle_input(_event, _owner):
     pass
 
 # called when state is created
-func init(_owner_obj):
+func init(_owner):
     pass
 
 # called before transitioning to a new state
-func exit(_owner_obj):
+func exit(_owner):
     pass

--- a/source/StateMachine.gd
+++ b/source/StateMachine.gd
@@ -38,6 +38,10 @@ func _process(delta):
     
     if current_state_handler and current_state_handler.has_method("update"):
         current_state_handler.update(delta, owner)
+
+func _physics_process(delta):
+    if current_state_handler and current_state_handler.has_method("physics_update"):
+        current_state_handler.physics_update(delta, owner)
         
 func _input(event):
     if current_state_handler and current_state_handler.has_method("handle_input"):


### PR DESCRIPTION
the ability to have states that update in sync with physics was missing so this updates StateMachine to implement _physics_process and the State interface now supports physics_update to handle this
