### PR TITLE
refactor! Transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is the most basic form of configuration. See the rest of this document for 
 
 #### add to scene
 
-There are at least two ways to use `StateMachine`. They ultimately do the same thing so the preference is really your own.
+There are several ways to use `StateMachine`. They ultimately do the same thing so the preference is really your own.
 
 1. (preferred way) Use the provided `StateMachine.tscn` and add it to your scene
 2. Add a new `Node` to your scene, and then attach the `StateMachine.gd` script to it.
@@ -56,13 +56,13 @@ Either way, it's recommended that you put all your available states into an enum
 
 ```gdscript
 enum STATES {
-    IDLE,
     WALKING,
     RUNNING,
+    JUMPING,
 }
 ```
 
-The `StateMachine` class exposes a `configure` method you can use to tell it about the available states. You can also specific the initial state to be in, if it's not the first one in the list. This would be the absolute barebones configuration for a state machine using the `STATES` above.
+The `StateMachine` class exposes a `configure` method you can use to tell it about the available states. You can also specify the initial state to be in, if it's not the first one in the list. This would be the absolute barebones configuration for a state machine using the `STATES` above.
 
 ```gdscript
 onready var state_machine = $StateMachine
@@ -77,8 +77,8 @@ Manually transitioning to a new state can be triggered at any time, but the chan
 
 ```gdscript
 func _input(event):
-    if event.is_action_pressed("walk_east"):
-        state_machine.transition_to_state(STATES.WALKING)
+    if event.is_action_pressed("jump"):
+        state_machine.transition_to_state(STATES.JUMPING)
 ```
 
 As long as the state passed into `transition_to_state` is one of the ones that was sent to `configure` then the current state will update next time `_process` ticks. It will emit a signal if the state changes, which is further documented below.
@@ -99,13 +99,13 @@ We will build out an object like so:
 }
 ```
 
-If you're using an enum, the keys in this object should be the enum values. The state machine class does not care if you just use strings, your own integers, but it's more error prone to do this compared to using the enum approach.
+If you're using an enum, the keys in this object should be the enum values. The state machine class does not care if you just use strings, or your own integers, but it's more error prone to do this compared to using the enum approach.
 
 The "next_state" key in the object must be one of the other state_ids; this property indicates what state to transition to next when this current one completes. This can be omitted if the state does not transition to any other state. This would be common with states like "death" where the node is cleared immediately after entering the state.
 
-The "state_class" is a class to instance for use when this state is active. You won't typically use the base `State` class directly since it is just an interface, but instead use an extension of it that implements the specific state behavior needed. More information about how to use this is available in the "State class" section below.
+The "state_class" is a class reference to instance for use when this state becomes active. You won't typically use the base `State` class directly since it is just an interface, but instead use an extension of it that implements the specific state behavior needed. More information about how to use this is available in the "State class" section below.
 
-If there are multiple states that are available as the "next state", use the key "transitions" instead. The value would be an object where the key is the "name" you want to give the transition, and the value is the state_id to transition to. This is shown in some of the examples below.
+If there are multiple states that are available as the "next state", use the key "transitions" instead. The value would be an object where the key is the "name" you use to reference the transition, and the value is the state_id to transition to. This is shown in some of the examples below.
 
 Here's the same states from the manual transitions example being configured for automated transitions.
 
@@ -148,14 +148,14 @@ Each of these requires a class existing to implement that state. Let's take a lo
 ```gdscript
 class JumpState extends State:
     func init(owner):
-        owner.jump()
+        owner.velocity.y = owner.jump_strength
 
     func process(delta, owner):
         if owner.is_on_floor():
             complete()
 ```
 
-When the state is initialized, `init` is called with `owner` node. For a state like `JumpState`, this is where we could tell the node to do its jump action. Then, in `process` (which is called every frame just like `_process`) we can check for the owner to have made it back to the floor, at which point we call the method `complete` (which is in the `State` base class) to emit a signal to tell the `StateMachine` to transition to the next state.
+When the state machine enters this state it creates an instance of this state class, and `init` is called with `owner` node. For a state like `JumpState`, this is where we could tell the node to do its jump action. Then, in `process` (which is called every frame just like `_process`) we can check for the owner to have made it back to the floor, at which point we call the method `complete` (which is in the `State` base class) to emit a signal to tell the `StateMachine` to transition to the next state.
 
 When using `next_state` the call to `complete` doesn't require any additional args.
 
@@ -243,7 +243,7 @@ class MiddleState extends State:
 
 ### transitioning back to the previous state
 
-Certain states are not going to fit into a flow that can be configured ahead of time and instead might interrupt multiple states, and want to return back to that previous state upon completion. An example could be something like a momentary freeze when damaged. Being damaged could happen while running, walking, jumping, swimming, etc. To handle this there is a special value which can be used, `StateMachine.PREVIOUS`. Using this as the "next_state" value will cause the state machine to return to the previous state when this one completes.
+Certain states are not going to fit into a flow that can be configured ahead of time and instead might interrupt another state, and then want to return back to that previous state upon completion. An example could be something like a momentary freeze when damaged. Being damaged could happen while running, walking, jumping, swimming, etc. To handle this there is a special value which can be used, `StateMachine.PREVIOUS`. Using this as the "next_state" value will cause the state machine to return to the previous state when this one completes.
 
 Currently, this is only implemented one level deep, so be careful not to return to a state which is also trying to return to a "previous" state. A future enhancemet would be to keep a larger stack of the history, but I haven't had a need for this yet.
 
@@ -256,32 +256,16 @@ Currently, this is only implemented one level deep, so be careful not to return 
 
 Under the hood the value of `PREVIOUS` is `-1`. In case this ever changes it would be safest to use the constant, but technically this value will work as well if it makes more sense to you.
 
-### example State implementation
-
-```gdscript
-class RespawnDelayState extends State:
-    func init(owner_ref):
-        context.time_elapsed = 0
-        context.wait_time = owner_ref.respawn_wait_time
-
-    func process(delta, owner_ref):
-        context.time_elapsed += delta
-
-        if context.time_elapsed >= context.wait_time:
-            complete()
-
-```
-
 ## StateMachine
 
-The `StateMachine` class is intended to be used directly. Instead of inheritance, it relies on being configured to operate. Once configured it can operate all on its own as described earlier in this document, but there are a few important methods to know about if going the manual route.
+The `StateMachine` class is intended to be attached to a node and used as is. It relies on configuration to operate. Once configured it can operate all on its own as described earlier in this document. There are a few handy methods to know about for gathering state information.
 
 | method name | purpose | args |
 |-------------|---------|------|
 | `get_current_state` | get the id of the current state | none |
 | `get_previous_state` | get the id of the state the machine was in before this one | none |
-| `is_current_state` | check if the current state is some other specific state | the `state_id` to compare against |
-| `transition_to` | manually set the state to transition into | the `state_id` to transition to |
+| `is_current_state` | check if the current state is some specific state | the `state_id` to compare against |
+| `transition_to` | manually change to a new state | the `state_id` to transition to |
 
 Some examples, because examples make everything easier!
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,29 @@ There are two main parts to this, the `StateMachine`, and the `State`. The `Stat
 
 ### Add the files to your project
 
-You'll need to add `source/StateMachine.gd` and `source/State.gd` to your project*. I usually add them in a directory like `res://helpers/`, but you can put them wherever you like. Since they set a `class_name`, they can be globally referenced by name no matter where you decide to put them.
+You'll need to add `source/StateMachine.gd` and `source/State.gd` to your project. I usually add them in a directory like `res://scripts/`, but you can put them wherever you like. Since they set a `class_name`, they can be globally referenced by name no matter where you decide to put them.
+
+I have also provided a `StateMachine.tscn` which is nothing more than a Node which the `StateMachine.gd` script attached. Using this is the quickest and easiest way to add a state machine to any scene in a project. Once added you can get a reference to it in script like so:
+
+```gdscript
+onready var state_machine = $StateMachine
+```
+
+Then you'll need to configure it like so:
+
+```gdscript
+enum STATES {
+    ONE,
+    TWO,
+}
+
+func _ready():
+    state_machine.configure(STATES)
+    state_machine.connect("state_changed", self, "_on_state_changed")
 
 ```
- *if for some reason you don't want to add two dependencies to your project, you can leave out `State.gd` and implement the same interface yourself. You're somewhat on your own if you go this route, just make sure you satisfy the methods that `StateMachine` needs in order to work.
-```
 
-If you added it to a node you can get a reference like so:
-
-`onready var state_machine = $StateMachine`
+This is the most basic form of configuration. See the rest of this document for more info about configuration, and state classes.
 
 ### Setup
 
@@ -30,10 +44,9 @@ If you added it to a node you can get a reference like so:
 
 There are at least two ways to use `StateMachine`. They ultimately do the same thing so the preference is really your own.
 
-1. Add a new `Node` to your scene, and then attach the `StateMachine.gd` script to it.
-2. Create an instance in script, and use `add_child` to add it.
-
-I personally use the first route most often so that the scene editor can tell me if something is using state, or not. It's also easy to use multiple StateMachine's with this approach and name them all in the inspector. Either way though, you're going to need a reference to your state machine in script to configure it.
+1. (preferred way) Use the provided `StateMachine.tscn` and add it to your scene
+2. Add a new `Node` to your scene, and then attach the `StateMachine.gd` script to it.
+3. Create an instance in script, and use `add_child` to add it.
 
 #### configure - manual transitions
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ There are two main parts to this, the `StateMachine`, and the `State`. The `Stat
 
 You'll need to add `source/StateMachine.gd` and `source/State.gd` to your project*. I usually add them in a directory like `res://helpers/`, but you can put them wherever you like. Since they set a `class_name`, they can be globally referenced by name no matter where you decide to put them.
 
-* \*if for some reason you don't want to add two dependencies to your project, you can leave out `State.gd` and implement the same interface yourself. You're somewhat on your own if you go this route, just make sure you satisfy the methods that `StateMachine` needs in order to work.
+```
+ *if for some reason you don't want to add two dependencies to your project, you can leave out `State.gd` and implement the same interface yourself. You're somewhat on your own if you go this route, just make sure you satisfy the methods that `StateMachine` needs in order to work.
+```
+
+If you added it to a node you can get a reference like so:
+
+`onready var state_machine = $StateMachine`
 
 ### Setup
 

--- a/source/State.gd
+++ b/source/State.gd
@@ -20,12 +20,12 @@ func complete(transition_key = null):
 func load_context(saved_context):
     context = saved_context
     
-# called from the StateMachine _process method
-func update(_delta, _owner):
+# called from the StateMachine _process method    
+func process(_delta, _owner):
     pass
 
 # called from StateMachine._physics_process 
-func physics_update(_delta, _owner):
+func physics_process(_delta, _owner):
     pass
 
 # called from _input

--- a/source/StateMachine.gd
+++ b/source/StateMachine.gd
@@ -75,6 +75,7 @@ func transition_to_next_state(transition_key = null):
     elif current_state.has("transitions") and current_state.transitions.has(transition_key):
         transition_to = current_state.transitions[transition_key]
     elif current_state.has("transition_to"): # DEPRECATED - left for backwards compatibility
+        print("state configuration using 'transition_to' is deprecated, please update to use 'next_state' or 'transitions'")
         if transition_key and current_state.transition_to.has(transition_key):
             transition_to = current_state.transition_to[transition_key]
         else:

--- a/source/StateMachine.gd
+++ b/source/StateMachine.gd
@@ -63,7 +63,13 @@ func transition_to_initial_state():
     transition_to_state(initial_state)
     
 func transition_to_next_state(transition_key = null):
-    if current_state.has("transition_to") and (transition_to == null or transition_to == current_state_name):
+    if transition_to != null and transition_to != current_state_name: return
+    
+    if current_state.has("next_state"):
+        transition_to = current_state.next_state
+    elif current_state.has("transitions") and current_state.transitions.has(transition_key):
+        transition_to = current_state.transitions[transition_key]
+    elif current_state.has("transition_to"): # DEPRECATED - left for backwards compatibility
         if transition_key and current_state.transition_to.has(transition_key):
             transition_to = current_state.transition_to[transition_key]
         else:

--- a/source/StateMachine.tscn
+++ b/source/StateMachine.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scripts/StateMachine.gd" type="Script" id=1]
+
+[node name="StateMachine" type="Node"]
+script = ExtResource( 1 )


### PR DESCRIPTION
BREAKING CHANGES!

State changes:
    - change `update` to `process`
    - change `physics_update` to `physics_process`
   
StateMachine configuration changes:
    - deprecate `transition_to` in favor of `next_state` or `transitions`
    - add `cache_states` ability

General:
    - add `StateMachine.tscn` scene node
    - README updates